### PR TITLE
feat(client): :sparkles: add commentator enable field

### DIFF
--- a/packages/client/src/components/Commentator.vue
+++ b/packages/client/src/components/Commentator.vue
@@ -10,6 +10,15 @@
             <strong>Commentator {{ index + 1 }}</strong>
         </div>
         <div class="card-body">
+            <div class="form-group form-check">
+                <input type="checkbox"
+                    class="form-check-input"
+                    id="commentator-enabled"
+                    v-model="commentator.enabled">
+                <label class="form-check-label" for="commentator-enabled">
+                    Enabled
+                </label>
+            </div>
             <div class="form-group">
                 <label>Name</label>
                 <input type="text" v-model="commentator.name" class="form-control" />

--- a/packages/client/src/components/Scoreboard.vue
+++ b/packages/client/src/components/Scoreboard.vue
@@ -141,7 +141,8 @@ function getEmptyEntrant(entrant) {
 function getEmptyCommentator() {
     return {
         name: '',
-        handle: ''
+        handle: '',
+        enabled: true
     };
 }
 

--- a/packages/server/data/schema/scoreboard.json
+++ b/packages/server/data/schema/scoreboard.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/schema#",
-    "id": "http://dserrano.duckdns.org/scoreboard/config/schemas/scoreboard.json",
+    "id": "http://dserrano.duckdns.org/scoreman/config/schemas/scoreboard.json",
     "title": "Scoreman scoreboard object",
 
     "type": "object",
@@ -81,7 +81,8 @@
             "type": "object",
             "properties": {
                 "name": { "type": "string" },
-                "handle": { "type": "string" }
+                "handle": { "type": "string" },
+                "enabled": { "type": "boolean" }
             },
             "additionalProperties": false
         },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -31,7 +31,7 @@
     "node-fetch": "^2.1.2",
     "passport": "^0.4.1",
     "passport-http": "^0.3.0",
-    "scoreman-overlay-melee-dark": "^1.2.0",
+    "scoreman-overlay-melee-dark": "^1.3.0",
     "serve-index": "^1.9.1",
     "yargs": "^16.2.0"
   }


### PR DESCRIPTION
This allows that commentators can enabled and disabled as they come and go. The overlays should use this new feature.

Closes #50