### PR TITLE
build(ci): :fire: remove useWorkspace param

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,6 @@
     ],
     "version": "0.6.2",
     "npmClient": "yarn",
-    "useWorkspaces": true,
     "command": {
         "publish": {
             "ignoreChanges": [


### PR DESCRIPTION
This option has been deprecated and stops github actions from working