### PR TITLE
fix(ci): :wastebasket: used $GITHUB_STATE instead of ::save-state

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=${yarn cache dir}" >> $GITHUB_OUTPUT
 
       - name: Cache yarn modules
         uses: actions/cache@v1


### PR DESCRIPTION
As explained in https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/