### PR TITLE
fix(ci): :construction_worker: add an yarn install step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
+      - name: Yarn install
+        run: yarn install
+
       - name: Build and release Electron binary
         run: |
           npx electron-builder build --publish always


### PR DESCRIPTION
We need this to download electron-builder (which was downloaded automatically) and electron-updater